### PR TITLE
zont_prom_exporter: add failure status and error code metrics

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Andrei Belov
+Copyright (c) 2024-2025 Andrei Belov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ but should work with other compatible devices as well.
 
 # Copyright
 
-Copyright © 2024 Andrei Belov. Released under the [MIT License](LICENSE).
+Copyright © 2024-2025 Andrei Belov. Released under the [MIT License](LICENSE).


### PR DESCRIPTION
This PR adds two more metrics to zont_prom_exporter:

```
# HELP zont_boiler_failed Boiler failure status
# TYPE zont_boiler_failed gauge
zont_boiler_failed{device_id="350878",sensor_id="20600"} 1.0
# HELP zont_boiler_error Latest error code
# TYPE zont_boiler_error gauge
zont_boiler_error{device_id="350878",sensor_id="20600"} 1.0
```